### PR TITLE
003/track page visit statistics

### DIFF
--- a/application.rb
+++ b/application.rb
@@ -5,9 +5,12 @@ require_relative './config/environment'
 require 'sinatra'
 require 'sinatra/flash'
 require 'sinatra/reloader' unless ENVIRONMENT == 'production'
+require 'date'
 
 require_relative './services/create_short_url_service'
 require_relative './services/short_url_by_hash_service'
+require_relative './models/page_visit'
+require_relative './services/track_visit_service'
 
 configure do
   enable :sessions
@@ -38,7 +41,9 @@ get '/:id' do
 
   @page = ShortUrlByHashService.new(id).find
 
-  redirect @page
+  TrackVisitService.new(@page).track
+
+  redirect @page.target_url
 rescue ShortUrlByHashService::PageNotFoundError
   flash[:error_title] = 'Unable to locate link'
   redirect '/'

--- a/db/migrations/0002_create_page_visits.rb
+++ b/db/migrations/0002_create_page_visits.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:page_visits) do
+      primary_key(:id)
+      DateTime :visited_at
+      foreign_key(:page_id, :pages)
+    end
+  end
+end

--- a/models/page_visit.rb
+++ b/models/page_visit.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative '../config/db_connection'
+
+class PageVisit < Sequel::Model
+end

--- a/services/short_url_by_hash_service.rb
+++ b/services/short_url_by_hash_service.rb
@@ -15,7 +15,7 @@ class ShortUrlByHashService
 
     raise PageNotFoundError if page.nil?
 
-    page.target_url
+    page
   end
 
   private

--- a/services/track_visit_service.rb
+++ b/services/track_visit_service.rb
@@ -1,0 +1,9 @@
+class TrackVisitService
+  def initialize(page)
+    @page = page
+  end
+
+  def track
+    PageVisit.create(visited_at: DateTime.now, page_id: @page.id)
+  end
+end

--- a/services/track_visit_service.rb
+++ b/services/track_visit_service.rb
@@ -1,3 +1,5 @@
+require_relative '../models/page'
+
 class TrackVisitService
   def initialize(page)
     @page = page

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -44,6 +44,24 @@ describe 'URL Shortener' do
 
         page.must_have_current_path 'http://other-test.com'
       end
+
+      it 'creates table entry' do
+        model = Page.create(target_url: 'http://other-test.com')
+
+        hasher = MiniTest::Mock.new
+        hasher.expect(:decode, [model.id], ['AB'])
+
+        Hashids.stub(:new, hasher) do
+          #lambda { visit '/AB' }.must_change(PageVisit.count)
+          #_(lambda { visit '/AB' }).must_change(PageVisit.count)
+          prev_count = PageVisit.count
+          visit '/AB'
+          _(PageVisit.count).must_equal(prev_count + 1)
+        end
+
+        #<banco?>.<entrada_possui_registro_correto> 
+
+      end
     end
 
     describe 'when there is not a page associated with the link' do

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -45,22 +45,18 @@ describe 'URL Shortener' do
         page.must_have_current_path 'http://other-test.com'
       end
 
-      it 'creates table entry' do
-        model = Page.create(target_url: 'http://other-test.com')
+      it 'registers that the page was visited' do
+        page = Page.create(target_url: 'http://other-test.com')
+        page_id = page.id
 
         hasher = MiniTest::Mock.new
-        hasher.expect(:decode, [model.id], ['AB'])
+        hasher.expect(:decode, [page.id], ['AB'])
 
         Hashids.stub(:new, hasher) do
-          #lambda { visit '/AB' }.must_change(PageVisit.count)
-          #_(lambda { visit '/AB' }).must_change(PageVisit.count)
-          prev_count = PageVisit.count
+          prev_count = PageVisit.where(page_id: page_id).count
           visit '/AB'
-          _(PageVisit.count).must_equal(prev_count + 1)
+          _(PageVisit.where(page_id: page_id).count).must_equal(prev_count + 1)
         end
-
-        #<banco?>.<entrada_possui_registro_correto> 
-
       end
     end
 

--- a/spec/services/short_url_by_hash_service_spec.rb
+++ b/spec/services/short_url_by_hash_service_spec.rb
@@ -13,7 +13,7 @@ describe ShortUrlByHashService do
     Hashids.stub(:new, hasher) do
       result = ShortUrlByHashService.new('AB').find
 
-      _(result).must_equal 'http://test.com'
+      _(result.target_url).must_equal 'http://test.com'
     end
   end
 end

--- a/spec/services/track_visit_service_spec.rb
+++ b/spec/services/track_visit_service_spec.rb
@@ -1,0 +1,14 @@
+require_relative '../unit_helper'
+require_relative '../../services/track_visit_service'
+require_relative '../../models/page'
+require_relative '../../models/page_visit'
+
+describe TrackVisitService do
+  it 'creates an entry in PageVists table' do
+    page = Page.create(target_url: 'http://other-test.com')
+
+    prev_count = PageVisit.count
+    TrackVisitService.new(page).track
+    _(PageVisit.count).must_equal(prev_count + 1)
+  end
+end


### PR DESCRIPTION
Issue 003: track page visit statistics

Included in this PR:
New PageVisits table to store shortened url  visit timestamps.

Not included in this PR:
Endpoint to show shortened url visit timestamps